### PR TITLE
adding tensorflow and singularity examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ To start a jupyter notebook in a specific directory:
 To start a jupyter notebook with tensorflow in a specific directory:
 
 `bash start.sh py2-tensorflow /path/to/dir`
-bash start.sh py2-tensorflow /scratch/users/vsochat
 
-If you want a GPU node, make sure your partition is set to "gpu"
+If you want a GPU node, make sure your partition is set to "gpu." 
 
 To start tensorboard in a specific directory (careful here and not recommended, as is not password protected):
 
@@ -89,6 +88,8 @@ If the sbatch job is still running, but your port forwarding stopped (e.g. if
 your computer went to sleep), you can resume with:
 
 `bash resume.sh jupyter`
+
+If you want to modify the partition flag to have a different gpu setup (other than `--partition gpu --gres gpu:1`) then you should set this **entire** string for the partition variable.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can always edit params.sh later to change these configuration options.
 
  - **PARTITION** If you intend to use a GPU (e.g., [sbatches/py2-tensorflow.sbatch](sbatches/py2-tensorflow.sbatch) the name of the PARTITION variable should be "gpu."
 
+If you want to modify the partition flag to have a different gpu setup (other than `--partition gpu --gres gpu:1`) then you should set this **entire** string for the partition variable.
 
 ### SSH config
 
@@ -107,8 +108,6 @@ If the sbatch job is still running, but your port forwarding stopped (e.g. if
 your computer went to sleep), you can resume with:
 
 `bash resume.sh jupyter`
-
-If you want to modify the partition flag to have a different gpu setup (other than `--partition gpu --gres gpu:1`) then you should set this **entire** string for the partition variable.
 
 ## Debugging
 Along with some good debugging notes [here](https://vsoch.github.io/lessons/jupyter-tensorflow#debugging), common errors are below.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Useful for jupyter notebook and tensorboard, amongst other things.
 ## Setup
 For interested users, a few tutorials are provided:
 
- - [sherlock jupyter](https://vsoch.github.io/lessons/sherlock-jupyter/).
- - [sherlock tensorflow](https://vsoch.github.io/lessons/sherlock-tensorflow/).
- - [sherlock singularity jupyter](https://vsoch.github.io/lessons/sherlock-tensorflow#singularity)
+ - [sherlock jupyter](https://vsoch.github.io/lessons/sherlock-jupyter/) 
+ - [sherlock tensorflow](https://vsoch.github.io/lessons/jupyter-tensorflow/)
+ - [sherlock singularity jupyter](https://vsoch.github.io/lessons/sherlock-singularity)
 
 Brief instructions are also documented in this README. Note that if you use a Singularity container,
 you don't need to set up a password on Sherlock (it will be generated for you on the fly).

--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Forward sets up an sbatch script on sherlock and port forwards it back to your l
 Useful for jupyter notebook and tensorboard, amongst other things.
 
 ## Setup
-For interested users, a [tutorial is provided](https://vsoch.github.io/lessons/sherlock-jupyter/). Instructions are also documented in this README.
+For interested users, a few tutorials are provided:
+
+ - [sherlock jupyter](https://vsoch.github.io/lessons/sherlock-jupyter/).
+ - [sherlock tensorflow](https://vsoch.github.io/lessons/sherlock-tensorflow/).
+ - [sherlock singularity jupyter](https://vsoch.github.io/lessons/sherlock-tensorflow#singularity)
+
+Brief instructions are also documented in this README. Note that if you use a Singularity container,
+you don't need to set up a password on Sherlock (it will be generated for you on the fly).
 
 ### Clone the Repository
 Clone this repository to your local machine.
@@ -76,6 +83,18 @@ To start a jupyter notebook with tensorflow in a specific directory:
 
 If you want a GPU node, make sure your partition is set to "gpu." 
 
+To start a jupyter notebook (via a Singularity container!) in a specific directory:
+
+`bash start.sh singularity-jupyter /path/to/dir`
+
+Want to create your own Singularity jupyter container? Use [repo2docker](https://www.github.com/jupyter/repo2docker) and then specify the container URI at the end:
+
+`bash start.sh singularity.jupyter /path/to/dir <container>`
+
+You can also run a general singularity container!
+
+`bash start.sh singularity /path/to/dir <container>`
+
 To start tensorboard in a specific directory (careful here and not recommended, as is not password protected):
 
 `bash start.sh start /path/to/dir`
@@ -92,6 +111,7 @@ your computer went to sleep), you can resume with:
 If you want to modify the partition flag to have a different gpu setup (other than `--partition gpu --gres gpu:1`) then you should set this **entire** string for the partition variable.
 
 ## Debugging
+Along with some good debugging notes [here](https://vsoch.github.io/lessons/jupyter-tensorflow#debugging), common errors are below.
 
 ### Connection refused after start.sh finished
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ You will then need to create a parameter file.  To do so, follow the prompts at:
 
 `bash setup.sh`
 
-You can always edit params.sh later to change these configuration options.
+You can always edit params.sh later to change these configuration options. 
+
+#### Parameters
+
+ - **PARTITION** If you intend to use a GPU (e.g., [sbatches/py-tensorflow-gpu.sbatch](sbatches/py-tensorflow-gpu.sbatch) the name of the PARTITION variable should be "gpu."
+
 
 ### SSH config
 
@@ -65,7 +70,14 @@ To start a jupyter notebook in a specific directory:
 
 `bash start.sh jupyter /path/to/dir`
 
-To start tensorboarrd in a specific directory (careful here and not recommended, as is not password protected):
+To start a jupyter notebook with tensorflow in a specific directory:
+
+`bash start.sh py2-tensorflow /path/to/dir`
+bash start.sh py2-tensorflow /scratch/users/vsochat
+
+If you want a GPU node, make sure your partition is set to "gpu"
+
+To start tensorboard in a specific directory (careful here and not recommended, as is not password protected):
 
 `bash start.sh start /path/to/dir`
 
@@ -92,10 +104,22 @@ Sometimes when you have changes in your network, you would need to reauthenticat
 In the same way you might get a login issue here, usually opening a new shell resolves 
 the hangup.
 
+### Terminal Hangs on "== Checking for previous notebook =="
+
+This is the same bug as above - this command specifically is capturing output into
+a variable, so if it hangs longer than 5-10 seconds, it's likely hit the password 
+prompt and would hang indefinitely. If you issue a standard command that will
+re-prompt for your password in the terminal session, you should fix the issue.
+
+```bash
+$ ssh sherlock pwd
+```
+
 ## I ended a script, but can't start
 
 As you would kill a job on Sherlock and see some delay for the node to come down, the
 same can be try here! Try waiting 20-30 seconds to give the node time to exit, and try again.
+
 
 ## How do I contribute?
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can always edit params.sh later to change these configuration options.
 
 #### Parameters
 
- - **PARTITION** If you intend to use a GPU (e.g., [sbatches/py-tensorflow-gpu.sbatch](sbatches/py-tensorflow-gpu.sbatch) the name of the PARTITION variable should be "gpu."
+ - **PARTITION** If you intend to use a GPU (e.g., [sbatches/py2-tensorflow.sbatch](sbatches/py2-tensorflow.sbatch) the name of the PARTITION variable should be "gpu."
 
 
 ### SSH config

--- a/sbatches/py2-tensorflow.sbatch
+++ b/sbatches/py2-tensorflow.sbatch
@@ -3,6 +3,7 @@ PORT=$1
 NOTEBOOK_DIR=$2
 cd $NOTEBOOK_DIR
 
+module load protobuf/3.4.0
 module load py-jupyter/1.0.0_py27
 module load py-tensorflow/1.8.0_py27
 

--- a/sbatches/py2-tensorflow.sbatch
+++ b/sbatches/py2-tensorflow.sbatch
@@ -1,0 +1,9 @@
+#!/bin/bash
+PORT=$1
+NOTEBOOK_DIR=$2
+cd $NOTEBOOK_DIR
+
+module load py-jupyter/1.0.0_py27
+module load py-tensorflow/1.8.0_py27
+
+jupyter notebook --no-browser --port=$PORT

--- a/sbatches/py3-tensorflow.sbatch
+++ b/sbatches/py3-tensorflow.sbatch
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PORT=$1
+NOTEBOOK_DIR=$2
+cd $NOTEBOOK_DIR
+
+module load py-jupyter/1.0.0_py36
+module load py-tensorflow/1.9.0_py36
+
+jupyter notebook --no-browser --port=$PORT

--- a/sbatches/singularity-jupyter.sbatch
+++ b/sbatches/singularity-jupyter.sbatch
@@ -18,6 +18,7 @@ PORT=$1
 NOTEBOOK_DIR=${2:-${SCRATCH}}
 CONTAINER=${3:-/scratch/users/vsochat/share/repo2docker.simg}
 
+module use system
 module load singularity
 export SINGULARITY_CACHEDIR="${SCRATCH}/.singularity"
 echo "Container is ${CONTAINER}"

--- a/sbatches/singularity-jupyter.sbatch
+++ b/sbatches/singularity-jupyter.sbatch
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+PORT=$1
+NOTEBOOK_DIR=$2
+CONTAINER=${3:-/scratch/users/vsochat/share/repo2docker.simg}
+cd $NOTEBOOK_DIR
+
+module load singularity
+export SINGULARITY_CACHEDIR=$SCRATCH/.singularity
+echo "Container is ${CONTAINER}"
+singularity exec ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0

--- a/sbatches/singularity-jupyter.sbatch
+++ b/sbatches/singularity-jupyter.sbatch
@@ -1,11 +1,26 @@
 #!/bin/bash
 
+# Usage
+
+# 1. Default Jupyter notebook (with your scratch to work in)
+# $ bash start.sh singularity-jupyter
+
+# 2. Default Jupyter notebook with custom working directory
+# $ bash start.sh singularity-jupyter /scratch/users/<username>
+
+# 3. Select your own jupyter container on Sherlock!
+# $ bash start.sh singularity-jupyter /scratch/users/<username> /path/to/container
+
+# 4. Or any singularity container...
+# $ bash start.sh singularity /path/to/container <args>
+
 PORT=$1
-NOTEBOOK_DIR=$2
+NOTEBOOK_DIR=${2:-${SCRATCH}}
 CONTAINER=${3:-/scratch/users/vsochat/share/repo2docker.simg}
-cd $NOTEBOOK_DIR
 
 module load singularity
-export SINGULARITY_CACHEDIR=$SCRATCH/.singularity
+export SINGULARITY_CACHEDIR="${SCRATCH}/.singularity"
 echo "Container is ${CONTAINER}"
+echo "Notebook directory is ${NOTEBOOK_DIR}"
+cd ${NOTEBOOK_DIR}
 singularity exec ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0

--- a/sbatches/singularity-jupyter.sbatch
+++ b/sbatches/singularity-jupyter.sbatch
@@ -23,4 +23,4 @@ export SINGULARITY_CACHEDIR="${SCRATCH}/.singularity"
 echo "Container is ${CONTAINER}"
 echo "Notebook directory is ${NOTEBOOK_DIR}"
 cd ${NOTEBOOK_DIR}
-singularity exec ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0
+singularity exec --home ${HOME} --bind ${HOME}/.local:/home/username/.local ${CONTAINER} jupyter notebook --no-browser --port=$PORT --ip 0.0.0.0

--- a/sbatches/singularity.sbatch
+++ b/sbatches/singularity.sbatch
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+CONTAINER=${1}
+NOTEBOOK_DIR=${2}
+shift shift
+cd $NOTEBOOK_DIR
+
+module load singularity
+export SINGULARITY_CACHEDIR=$SCRATCH/.singularity
+singularity exec ${CONTAINER} "${@}"

--- a/sbatches/singularity.sbatch
+++ b/sbatches/singularity.sbatch
@@ -5,6 +5,7 @@ NOTEBOOK_DIR=${2}
 shift shift
 cd $NOTEBOOK_DIR
 
+module use system
 module load singularity
 export SINGULARITY_CACHEDIR=$SCRATCH/.singularity
 singularity exec ${CONTAINER} "${@}"

--- a/setup.sh
+++ b/setup.sh
@@ -26,8 +26,6 @@ echo
 read -p "Browser to use (default: /Applications/Safari.app/) > "  BROWSER
 BROWSER=${BROWSER:-"/Applications/Safari.app/"}
 
-/bin/bash
-
 MEM=20G
 
 TIME=8:00:00

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,8 @@ echo
 read -p "Browser to use (default: /Applications/Safari.app/) > "  BROWSER
 BROWSER=${BROWSER:-"/Applications/Safari.app/"}
 
+/bin/bash
+
 MEM=20G
 
 TIME=8:00:00

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,7 @@
 # Sample usage: bash start.sh jupyter
 #               bash start.sh jupyter /home/users/raphtown
 #               bash start.sh tensorboard /home/users/raphtown
+
 if [ ! -f params.sh ]
 then
     echo "Need to configure params before first run, run setup.sh!"
@@ -52,15 +53,26 @@ ssh sherlock mkdir -p $SHERLOCK_HOME/forward-util
 echo "== Uploading sbatch script =="
 scp sbatches/$SBATCH sherlock:$SHERLOCK_HOME/forward-util/
 
+# Give them one gpu :)
+if [ "${PARTITION}" == "gpu" ];
+  then
+      echo "== Requesting GPU =="
+      PARTITION="${PARTITION} --gres gpu:1"
+  fi
+
 echo "== Submitting sbatch =="
-ssh sherlock sbatch \
-    --job-name=$NAME \
-    --partition=$PARTITION \
-    --output=$SHERLOCK_HOME/forward-util/$NAME.out \
-    --error=$SHERLOCK_HOME/forward-util/$NAME.err \
-    --mem=$MEM \
-    --time=$TIME \
-    $SHERLOCK_HOME/forward-util/$SBATCH $PORT "${@:2}"
+
+command="sherlock sbatch
+    --job-name=$NAME
+    --partition=$PARTITION
+    --output=$SHERLOCK_HOME/forward-util/$NAME.out
+    --error=$SHERLOCK_HOME/forward-util/$NAME.err
+    --mem=$MEM
+    --time=$TIME
+    $SHERLOCK_HOME/forward-util/$SBATCH $PORT \"${@:2}\""
+
+echo ${command}
+ssh ${command}
 
 echo "== Waiting for job to start, using exponential backoff =="
 MACHINE=""

--- a/start.sh
+++ b/start.sh
@@ -110,9 +110,14 @@ fi
 
 echo "notebook running on $MACHINE"
 echo "== Setting up port forwarding =="
+sleep 5
 echo "ssh -L $PORT:localhost:$PORT sherlock ssh -L $PORT:localhost:$PORT -N $MACHINE &"
 ssh -L $PORT:localhost:$PORT sherlock ssh -L $PORT:localhost:$PORT -N "$MACHINE" &
 
 sleep 5
 echo "== Connecting to notebook =="
+
+# Print logs for the user, in case needed
+ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.out
+ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.err
 echo "Open your browser to http://localhost:$PORT"

--- a/start.sh
+++ b/start.sh
@@ -118,6 +118,9 @@ sleep 5
 echo "== Connecting to notebook =="
 
 # Print logs for the user, in case needed
+echo "== View Logs Like This =="
+echo "ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.out"
+echo "ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.err"
 ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.out
 ssh sherlock cat $SHERLOCK_HOME/forward-util/${NAME}.err
 echo "Open your browser to http://localhost:$PORT"


### PR DESCRIPTION
hey @raphtown ! I just worked on this (slightly modified) example that will load up the same python 2 or 3 notebook, but also with tensorflow! I have a matching tutorial to post along with it, to give a bit more context. --> https://vsoch.github.io/lessons/jupyter-tensorflow/

Also, I think I just got a wicked idea - it's pretty annoying to need to load sherlock modules (then half the time something still doesn't work) so how cool would it be to just provide things in containers? And then the user can pick / share containers with things ready to go? There is also a thing called [repo2docker](https://github.com/jupyter/repo2docker/pull/351) that would make it totally seamless to go from a jupyter notebook, to docker container, to singularity container (for sherlock). So - after this post, how about I'll give a go at "the container version?" I'd want to also include the repo2docker as part of the tutorial, so these two guys would need to be merged first:

 - https://github.com/binder-examples/continuous-build/pull/4
 - https://github.com/jupyter/repo2docker/pull/351