### PR TITLE
Use hash for ControlPath to keep it short

### DIFF
--- a/hosts/farmshare_ssh.sh
+++ b/hosts/farmshare_ssh.sh
@@ -17,4 +17,4 @@ echo "Host farmshare
     GSSAPIAuthentication yes
     ControlMaster auto
     ControlPersist yes
-    ControlPath ~/.ssh/%l%r@%h:%p"
+    ControlPath ~/.ssh/%C"

--- a/hosts/sherlock_ssh.sh
+++ b/hosts/sherlock_ssh.sh
@@ -16,4 +16,4 @@ echo "Host sherlock
     GSSAPIAuthentication yes
     ControlMaster auto
     ControlPersist yes
-    ControlPath ~/.ssh/%l%r@%h:%p"
+    ControlPath ~/.ssh/%C"


### PR DESCRIPTION
This PR changes the default ssh config such that the `ControlPath` used by `ssh` is basically a _hash_ of the previous name, preventing an excessively long local hostname (as can be assigned at SLAC) from making the ControlPath too long and creating an SSH error.

(See also https://github.com/vsoch/forward/issues/31)