### PR TITLE
updating USERNAME to be FORWARD_USERNAME

### DIFF
--- a/end.sh
+++ b/end.sh
@@ -20,7 +20,7 @@ fi
 NAME=$1
 
 echo "Killing $NAME slurm job on ${RESOURCE}"
-ssh ${RESOURCE} "squeue --name=$NAME --user=$USERNAME -o '%A' -h | xargs --no-run-if-empty /usr/bin/scancel"
+ssh ${RESOURCE} "squeue --name=$NAME --user=$FORWARD_USERNAME -o '%A' -h | xargs --no-run-if-empty /usr/bin/scancel"
 
 echo "Killing listeners on ${RESOURCE}"
 ssh ${RESOURCE} "/usr/sbin/lsof -i :$PORT -t | xargs --no-run-if-empty kill"

--- a/helpers.sh
+++ b/helpers.sh
@@ -45,7 +45,7 @@ function set_forward_script() {
 function check_previous_submit() {
 
     echo "== Checking for previous notebook =="
-    PREVIOUS=`ssh ${RESOURCE} squeue --name=$NAME --user=$USERNAME -o "%R" -h`
+    PREVIOUS=`ssh ${RESOURCE} squeue --name=$NAME --user=$FORWARD_USERNAME -o "%R" -h`
     if [ -z "$PREVIOUS" -a "${PREVIOUS+xxx}" = "xxx" ]; 
         then
             echo "No existing ${NAME} jobs found, continuing..."
@@ -79,7 +79,7 @@ function get_machine() {
     while [[ $ALLOCATED == "no" ]]
       do
                                                                   # nodelist
-          MACHINE=`ssh ${RESOURCE} squeue --name=$NAME --user=$USERNAME -o "%N" -h`
+          MACHINE=`ssh ${RESOURCE} squeue --name=$NAME --user=$FORWARD_USERNAME -o "%N" -h`
     
           if [[ "$MACHINE" != "" ]]
           then
@@ -97,7 +97,7 @@ function get_machine() {
     done
 
     echo $MACHINE
-    MACHINE="`ssh ${RESOURCE} squeue --name=$NAME --user=$USERNAME -o "%R" -h`"
+    MACHINE="`ssh ${RESOURCE} squeue --name=$NAME --user=$FORWARD_USERNAME -o "%R" -h`"
     echo $MACHINE
 
     # If we didn't get a node...

--- a/hosts/farmshare_ssh.sh
+++ b/hosts/farmshare_ssh.sh
@@ -4,14 +4,14 @@
 # Prints an ssh configuration for the user, selecting a login node at random
 # Sample usage: bash farmshare_ssh.sh
 echo
-read -p "Farmshare username > "  USERNAME
+read -p "Farmshare username > "  FORWARD_USERNAME
 
 # The FarmShare login node is (as of 2018) rice.stanford.edu.  That is a
 # load-balanced DNS.  The use of ControlMaster will ensure that multiple
 # connections to rice.stanford.edu all go to the same host.
 
 echo "Host farmshare
-    User ${USERNAME}
+    User ${FORWARD_USERNAME}
     Hostname rice.stanford.edu
     GSSAPIDelegateCredentials yes
     GSSAPIAuthentication yes

--- a/hosts/sherlock_ssh.sh
+++ b/hosts/sherlock_ssh.sh
@@ -4,13 +4,13 @@
 # Prints an ssh configuration for the user, selecting a login node at random
 # Sample usage: bash sherlock_ssh.sh
 echo
-read -p "Sherlock username > "  USERNAME
+read -p "Sherlock username > "  FORWARD_USERNAME
 
 # Randomly select login node from 1..4
 LOGIN_NODE=$((1 + RANDOM % 8))
 
 echo "Host sherlock
-    User ${USERNAME}
+    User ${FORWARD_USERNAME}
     Hostname sh-ln0${LOGIN_NODE}.stanford.edu
     GSSAPIDelegateCredentials yes
     GSSAPIAuthentication yes

--- a/resume.sh
+++ b/resume.sh
@@ -14,6 +14,6 @@ NAME="${1}"
 
 # The user is required to specify port
 
-echo "ssh ${RESOURCE} squeue --name=$NAME --user=$USERNAME -o "%N" -h"
-MACHINE=`ssh ${RESOURCE} squeue --name=$NAME --user=$USERNAME -o "%N" -h`
+echo "ssh ${RESOURCE} squeue --name=$NAME --user=$FORWARD_USERNAME -o "%N" -h"
+MACHINE=`ssh ${RESOURCE} squeue --name=$NAME --user=$FORWARD_USERNAME -o "%N" -h`
 ssh -L $PORT:localhost:$PORT ${RESOURCE} ssh -L $PORT:localhost:$PORT -N $MACHINE &

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ read -p "Resource identifier (default: sherlock) > "  RESOURCE
 RESOURCE=${RESOURCE:-sherlock}
 
 echo
-read -p "${RESOURCE} username > "  USERNAME
+read -p "${RESOURCE} username > "  FORWARD_USERNAME
 
 echo
 echo "Next, pick a port to use.  If someone else is port forwarding using that
@@ -43,7 +43,7 @@ MEM=20G
 
 TIME=8:00:00
 
-for var in USERNAME PORT PARTITION RESOURCE MEM TIME CONTAINERSHARE
+for var in FORWARD_USERNAME PORT PARTITION RESOURCE MEM TIME CONTAINERSHARE
 do
     echo "$var="'"'"$(eval echo '$'"$var")"'"'
 done >> params.sh

--- a/start-node.sh
+++ b/start-node.sh
@@ -79,4 +79,4 @@ echo "== Connecting to resource =="
 print_logs
 
 echo "Connect to machine:"
-echo "ssh -t ${RESOURCE} ssh ${USERNAME}@${MACHINE}"
+echo "ssh -t ${RESOURCE} ssh ${FORWARD_USERNAME}@${MACHINE}"


### PR DESCRIPTION
It seems like Macs can already define a USERNAME variable, in which case the one set by forward is not honored. To fix this, we instead define and use a `FORWARD_USERNAME`. This PR includes minimal work for that change.

Signed-off-by: vsoch <vsochat@stanford.edu>