### PR TITLE
add wait time for slow cluster response

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can always edit `params.sh` later to change these configuration options.
  - **RESOURCE** should refer to an identifier for your cluster resource that will be recorded in your ssh configuration, and then referenced in the scripts to interact with the resource (e.g., `ssh sherlock`).
  - **PARTITION** If you intend to use a GPU (e.g., [sbatches/py2-tensorflow.sbatch](sbatches/py2-tensorflow.sbatch) the name of the PARTITION variable should be "gpu."
  - **CONTAINERSHARE** (optional) is a location on your cluster resource (typically world readable) where you might find containers (named by a hash of the container name in the [library]() that are ready to go! If you are at Stanford, leave this to be default. If you aren't, then ask your cluster admin about [setting up a containershare](https://www.github.com/vsoch/containershare)
+ - **CONNECTION_WAIT_SECONDS** refers to how many seconds the start.sh script waits before setting up port forwarding. If your cluster runs slow, or is particularly busy, this can be set at 30. 
 
 If you want to modify the partition flag to have a different gpu setup (other than `--partition gpu --gres gpu:1`) then you should set this **entire** string for the partition variable.
 
@@ -250,6 +251,11 @@ export TIMEOUT=3
 ```
 
 While the forward tool cannot control the busyness of slurm, these two strategies should help a bit.
+
+### mux_client_forward: forwarding request failed: Port forwarding failed 
+
+
+Similarly, if your cluster is slow, you may get this error after "== Setting up port forwarding ==". To fix this, increase your CONNECTION_WAIT_SECONDS. 
 
 ### I ended a script, but can't start
 

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,11 @@ then
    CONTAINERSHARE=${CONTAINERSHARE:-library://sohams/default/farmsharejupyter:latest}
 fi
 
+echo
+echo "Finally, how many seconds would you like to wait for a connection (ideal for slower clusters, defaults to 0 seconds for no timeout)?"
+echo
+read -p "Seconds to wait > "  CONNECTION_WAIT_SECONDS
+
 
 
 MEM=20G
@@ -84,7 +89,7 @@ MEM=20G
 TIME=8:00:00
 
 
-for var in FORWARD_USERNAME PORT PARTITION RESOURCE MEM TIME CONTAINERSHARE MACHINEPREFIX DOMAINNAME USE_LSOF ISOLATEDCOMPUTENODE
+for var in FORWARD_USERNAME PORT PARTITION RESOURCE MEM TIME CONTAINERSHARE MACHINEPREFIX DOMAINNAME USE_LSOF ISOLATEDCOMPUTENODE CONNECTION_WAIT_SECONDS
 do
     echo "$var="'"'"$(eval echo '$'"$var")"'"'
 done >> params.sh

--- a/setup.sh
+++ b/setup.sh
@@ -78,9 +78,11 @@ then
 fi
 
 echo
-echo "Finally, how many seconds would you like to wait for a connection (ideal for slower clusters, defaults to 0 seconds for no timeout)?"
+echo "Finally, how many seconds would you like to wait for a connection?"
 echo
-read -p "Seconds to wait > "  CONNECTION_WAIT_SECONDS
+read -p "Seconds to wait (default, 0) > "  CONNECTION_WAIT_SECONDS
+CONNECTION_WAIT_SECONDS=${CONNECTION_WAIT_SECONDS:-0}
+
 
 
 

--- a/start.sh
+++ b/start.sh
@@ -70,9 +70,10 @@ instruction_get_logs
 get_machine
 echo "notebook running on $MACHINE"
 
+sleep $CONNECTION_WAIT_SECONDS
+
 setup_port_forwarding
 
-sleep 10
 echo "== Connecting to notebook =="
 
 # Print logs for the user, in case needed


### PR DESCRIPTION
Changes discussed in Issue #41 - creating a variable CONNECTION_WAIT_SECONDS that determines how long `start.sh` should sleep before setting up port forwarding to accommodate slow cluster response time. 

To test: rerun `setup.sh` and then run any of the sbatch jobs with `start.sh`. Your code will now wait between 0-30 seconds (dependent on what's in your `params.sh`)  before setting up port forwarding. 